### PR TITLE
fix: Prevent type narrowing of union types (bools, enums, etc) in `FactoryDefaults`

### DIFF
--- a/src/__tests__/factories.test.ts
+++ b/src/__tests__/factories.test.ts
@@ -10,6 +10,28 @@ describe("Factory APIs", () => {
   };
 
   describe("Factory", () => {
+    describe("enumerated values", () => {
+      it("should allow a function that returns a boolean for a boolean property", () => {
+        type TestObject = { bool: boolean };
+        const randBoolean = (): boolean => Math.random() > 0.5;
+
+        createFactory<TestObject>({ bool: randBoolean }); // Expect no type error here
+      });
+
+      it("should allow a function that returns an enum for an enum property", () => {
+        enum TestEnum {
+          A,
+          B,
+          C,
+        }
+        type TestObject = { value: TestEnum };
+        const randTestEnum = (): TestEnum =>
+          [TestEnum.A, TestEnum.B, TestEnum.C][Math.floor(Math.random() * 3)]!;
+
+        createFactory<TestObject>({ value: randTestEnum }); // Expect no type error here
+      });
+    });
+
     describe("when traits are not defined in the second type parameter", () => {
       it("should be just a function", () => {
         type Actual = Factory<User>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,14 +37,15 @@ function isMergeable(val: any): val is Record<string, any> {
   );
 }
 
-export type FactoryDefaults<T> =
-  T extends Array<any>
-    ? T | (() => T)
-    : T extends Record<string, any>
-      ? { [key in keyof T]: FactoryDefaults<T[key]> }
-      : T extends Function
+export type FactoryDefaults<T extends Record<string, any>> = {
+  [Key in keyof T]: T[Key] extends Array<any>
+    ? T[Key] | (() => T[Key])
+    : T[Key] extends Record<string, any>
+      ? FactoryDefaults<T[Key]>
+      : T[Key] extends Function
         ? never
-        : T | (() => T);
+        : T[Key] | (() => T[Key]);
+};
 
 export function resolveDefaults<T extends Record<string, any>>(
   val: FactoryDefaults<T>,


### PR DESCRIPTION
New tests were throwing an error:

<details>

```
$ bun tsc
src/__tests__/factories.test.ts:18:43 - error TS2322: Type '() => boolean' is not assignable to type 'boolean | (() => false) | (() => true)'.
  Type '() => boolean' is not assignable to type '() => false'.
    Type 'boolean' is not assignable to type 'false'.

18         createFactory<TestObject>({ bool: randBoolean }); // Expect no type error here
                                             ~~~~~~~~~~~

  src/__tests__/factories.test.ts:18:43
    18         createFactory<TestObject>({ bool: randBoolean }); // Expect no type error here
                                                 ~~~~~~~~~~~
    Did you mean to call this expression?

src/__tests__/factories.test.ts:31:44 - error TS2322: Type '() => TestEnum' is not assignable to type 'TestEnum | (() => TestEnum.A) | (() => TestEnum.B) | (() => TestEnum.C)'.
  Type '() => TestEnum' is not assignable to type '() => TestEnum.A'.
    Type 'TestEnum' is not assignable to type 'TestEnum.A'.

31         createFactory<TestObject>({ value: randTestEnum }); // Expect no type error here
                                              ~~~~~~~~~~~~

  src/__tests__/factories.test.ts:31:44
    31         createFactory<TestObject>({ value: randTestEnum }); // Expect no type error here
                                                  ~~~~~~~~~~~~
    Did you mean to call this expression?


Found 2 errors in the same file, starting at: src/__tests__/factories.test.ts:18

error: "tsc" exited with code 2
```

</details>

Seems like tweaking the recursion to take objects not any value fixed it.